### PR TITLE
Update GNOME runtime to version 46

### DIFF
--- a/io.github.quodlibet.ExFalso.yaml
+++ b/io.github.quodlibet.ExFalso.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.quodlibet.ExFalso
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: exfalso
 build-options:


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.